### PR TITLE
Add timestamps to screams

### DIFF
--- a/config/models
+++ b/config/models
@@ -6,3 +6,4 @@ User
 
 Scream
     body Markdown
+    createdAt UTCTime

--- a/src/Handler/Home.hs
+++ b/src/Handler/Home.hs
@@ -4,6 +4,6 @@ import Import
 
 getHomeR :: Handler Html
 getHomeR = do
-    screams <- runDB $ selectList [] [Desc ScreamId]
+    screams <- runDB $ selectList [] [Desc ScreamCreatedAt, Desc ScreamId]
     defaultLayout $ do
         $(widgetFile "home/index")

--- a/src/Handler/NewScream.hs
+++ b/src/Handler/NewScream.hs
@@ -4,36 +4,38 @@ module Handler.NewScream
     ) where
 
 import Import
-import Yesod.Form.Bootstrap3
-    ( renderBootstrap3
-    , BootstrapFormLayout(..)
-    )
-import Yesod.Markdown (markdownField)
-import Yesod.Form.Functions (FormRender)
+import Yesod.Markdown (Markdown, markdownField)
 
-screamForm :: AForm Handler Scream
-screamForm = Scream
-    <$> areq markdownField "Body" Nothing
+data ScreamFields = ScreamFields
+    { bodyField :: Markdown
+    }
+
+fromScreamFields :: ScreamFields -> Handler Scream
+fromScreamFields f = do
+    now <- liftIO getCurrentTime
+    return Scream
+        { screamBody = bodyField f
+        , screamCreatedAt = now
+        }
+
+screamForm :: Form ScreamFields
+screamForm = renderDivs $
+    ScreamFields
+        <$> areq markdownField "Body" Nothing
 
 getNewScreamR :: Handler Html
 getNewScreamR = do
-    (form, enctype) <- generateForm screamForm
+    (form, enctype) <- generateFormPost screamForm
     defaultLayout $ do
         setTitle "New Scream"
         $(widgetFile "screams/new")
-    where
-        generateForm = generateFormPost . bootstrapForm
 
 postNewScreamR :: Handler Html
 postNewScreamR = do
-    ((res, form), enctype) <- runForm screamForm
+    ((res, form), enctype) <- runFormPost screamForm
     case res of
-      FormSuccess scream -> do
+      FormSuccess fields -> do
+          scream <- fromScreamFields fields
           _screamId <- runDB $ insert scream
           redirect HomeR
       _ -> defaultLayout $(widgetFile "screams/new")
-    where
-        runForm = runFormPost . bootstrapForm
-
-bootstrapForm :: Monad m => FormRender m a
-bootstrapForm = renderBootstrap3 BootstrapBasicForm


### PR DESCRIPTION
I'd like to know when screams were posted. That seems important.
Unfortunately, I was unable to find a nice way to make this work using
hidden fields or anything, so I needed to use the same technique used in
[Ask] and create a new datatype to represent the form fields. Then I'm
able to supply a default creation time to the scream when I parse it out
of those fields.

I'm also setting the timestamp as the primary sort key, falling back to
the id in the case of a tie (unlikely).