### PR TITLE
Require authentication for screams

### DIFF
--- a/featureless-void.cabal
+++ b/featureless-void.cabal
@@ -91,6 +91,8 @@ library
                  , case-insensitive
                  , wai
                  , yesod-markdown
+                 , yesod-auth-hashdb
+                 , pwstore-fast
 
 executable         featureless-void
     if flag(library-only)

--- a/src/Foundation.hs
+++ b/src/Foundation.hs
@@ -119,13 +119,6 @@ instance Yesod App where
 
     makeLogger = return . appLogger
 
-
--- Define breadcrumbs.
-instance YesodBreadcrumbs App where
-  breadcrumb HomeR = return ("Home", Nothing)
-  breadcrumb (AuthR _) = return ("Login", Just HomeR)
-  breadcrumb  _ = return ("home", Nothing)
-
 -- How to run database actions.
 instance YesodPersist App where
     type YesodPersistBackend App = SqlBackend

--- a/src/Model.hs
+++ b/src/Model.hs
@@ -5,6 +5,7 @@ module Model where
 import ClassyPrelude.Yesod
 import Database.Persist.Quasi
 import Yesod.Markdown
+import Yesod.Auth.HashDB (HashDBUser(..))
 
 -- You can define all of your database entities in the entities file.
 -- You can find more information on persistent and how to declare entities
@@ -12,3 +13,7 @@ import Yesod.Markdown
 -- http://www.yesodweb.com/book/persistent/
 share [mkPersist sqlSettings, mkMigrate "migrateAll"]
     $(persistFileWith lowerCaseSettings "config/models")
+
+instance HashDBUser User where
+    userPasswordHash = userPassword
+    setPasswordHash h u = u { userPassword = Just h }


### PR DESCRIPTION
We want to make sure Joe Schmo isn't able to scream on my behalf. I've 
decided to use yesod-auth-hashdb for the authentication, because all I 
actually care about is one single user (me) and I'm happy to manually 
create my credentials in the database.

I'm exposing `pwstore-fast` in order to be able to import it in ghci so 
that I can generate the correct password hash.