### PR TITLE
Don't let users post screams longer than 280 chars

### DIFF
--- a/src/Handler/NewScream.hs
+++ b/src/Handler/NewScream.hs
@@ -21,7 +21,7 @@ fromScreamFields f = do
 screamForm :: Form ScreamFields
 screamForm = renderDivs $
     ScreamFields
-        <$> areq markdownField "Body" Nothing
+        <$> areq markdownField ("Body" { fsId = Just "scream-body" }) Nothing
 
 getNewScreamR :: Handler Html
 getNewScreamR = do

--- a/static/js/char-count.js
+++ b/static/js/char-count.js
@@ -1,0 +1,18 @@
+$('#scream-body').on('input', function() {
+  var count = $(this).val().length
+  $('#scream-length').text(count);
+
+  if (count > 280) {
+    $('#scream-length').removeClass('valid-scream').addClass('invalid-scream')
+    $('#submit').prop('disabled', true)
+  } else {
+    $('#scream-length').removeClass('invalid-scream').addClass('valid-scream')
+    $('#submit').prop('disabled', false)
+  }
+
+  if (count > 140) {
+    $('#scream-length').removeClass('valid-tweet')
+  } else {
+    $('#scream-length').addClass('valid-tweet')
+  }
+});

--- a/templates/default-layout-wrapper.hamlet
+++ b/templates/default-layout-wrapper.hamlet
@@ -11,6 +11,8 @@ $doctype 5
 
     ^{pageHead pc}
 
+    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.4/jquery.js">
+
   <body>
     ^{pageBody pc}
     ^{csrfTokenJs}

--- a/templates/screams/new.hamlet
+++ b/templates/screams/new.hamlet
@@ -1,5 +1,9 @@
-<h1> Scream into the void!
+<h1>Scream into the void!
 
 <form method=post action=@{NewScreamR} enctype=#{enctype}>
   ^{form}
-  <input type="submit" value="Scream!" />
+  <span #scream-length .valid-scream .valid-tweet>0 #
+  <span #screamTotal>/280
+  <button #submit>Scream!
+
+<script type="text/javascript" src="/static/js/char-count.js">


### PR DESCRIPTION
We want to make sure we're forcing users (me) to be brief. To this end,
we should keep track of the character count and explicitly disallow
screams longer than 280 chars. This length is arbitrary, but it's
consistent with what micro.blog will be expecting, so it seems
reasonable.

Additionally, we can keep track of if the scream is also a valid tweet.
This is useful info to have since micro.blog will (eventually) be
handling crossposting to twitter.