### PR TITLE
Paginate screams

### DIFF
--- a/featureless-void.cabal
+++ b/featureless-void.cabal
@@ -26,6 +26,7 @@ library
                      Model
                      Settings
                      Settings.StaticFiles
+                     Yesod.Paginator.Simple
 
     if flag(dev) || flag(library-only)
         cpp-options:   -DDEVELOPMENT
@@ -96,6 +97,7 @@ library
                  , yesod-markdown
                  , yesod-auth-hashdb
                  , pwstore-fast
+                 , yesod-paginator
 
 executable         featureless-void
     if flag(library-only)

--- a/src/Handler/Home.hs
+++ b/src/Handler/Home.hs
@@ -2,9 +2,17 @@ module Handler.Home where
 
 import Import
 import Helper
+import Yesod.Paginator.Simple
 
 getHomeR :: Handler Html
 getHomeR = do
-    screams <- runDB $ selectList [] [Desc ScreamCreatedAt, Desc ScreamId]
+    (screams, pagination) <- fetchScreams
     defaultLayout $ do
         $(widgetFile "home/index")
+
+fetchScreams :: Handler ([Entity Scream], Widget)
+fetchScreams = runDB $
+    selectSimplePaginated
+        30                                    -- number of items per page
+        []                                    -- filters
+        [Desc ScreamCreatedAt, Desc ScreamId] -- sort descriptors

--- a/src/Handler/Home.hs
+++ b/src/Handler/Home.hs
@@ -2,6 +2,7 @@ module Handler.Home where
 
 import Import
 import Helper
+import Yesod.Paginator
 import Yesod.Paginator.Simple
 
 getHomeR :: Handler Html
@@ -12,7 +13,8 @@ getHomeR = do
 
 fetchScreams :: Handler ([Entity Scream], Widget)
 fetchScreams = runDB $
-    selectSimplePaginated
+    selectPaginatedWith
+        simplePaginationWidget                -- pagination widget
         30                                    -- number of items per page
         []                                    -- filters
         [Desc ScreamCreatedAt, Desc ScreamId] -- sort descriptors

--- a/src/Yesod/Paginator/Simple.hs
+++ b/src/Yesod/Paginator/Simple.hs
@@ -1,0 +1,55 @@
+module Yesod.Paginator.Simple
+    ( selectSimplePaginated
+    , simplePaginationWidget
+    ) where
+
+import Import
+import Yesod.Paginator
+import qualified Data.Text as T
+
+selectSimplePaginated :: (PersistEntityBackend val ~ SqlBackend,
+                                PersistEntity val) =>
+                                    Int
+                                    -> [Filter val]
+                                    -> [SelectOpt val]
+                                    -> ReaderT SqlBackend Handler ([Entity val], Widget)
+selectSimplePaginated = selectPaginatedWith simplePaginationWidget
+
+simplePaginationWidget :: PageWidget App
+simplePaginationWidget page per tot = do
+    -- total number of pages
+    let pages = (\(n, r) -> n + (min r 1)) $ tot `divMod` per
+    curParams <- handlerToWidget $ liftM reqGetParams getRequest
+
+    [whamlet|$newline never
+        <ul class="pagination">
+            $forall link <- buildLinks page pages
+                ^{showLink curParams link}
+    |]
+
+    where
+        buildLinks :: Int -> Int -> [PageLink]
+        buildLinks pg pgs = concat
+            [ PageLink (pg - 1) "Newer" <$ (guard $ pg /= 1)
+            , PageLink (pg + 1) "Older" <$ (guard $ pg /= pgs)
+            ]
+
+data PageLink = PageLink Int Text
+
+showLink :: [(Text, Text)] -> PageLink -> Widget
+showLink params (PageLink pg txt) = do
+    let param = ("p", showT pg)
+
+    [whamlet|$newline never
+        <li>
+            <a href="#{updateGetParam params param}">#{txt}
+    |]
+
+    where
+        updateGetParam :: [(Text,Text)] -> (Text,Text) -> Text
+        updateGetParam getParams (p, n) = (T.cons '?') . T.intercalate "&"
+                                        . map (\(k,v) -> k `T.append` "=" `T.append` v)
+                                        . (++ [(p, n)]) . filter ((/= p) . fst) $ getParams
+
+showT :: (Show a) => a -> Text
+showT = T.pack . show

--- a/src/Yesod/Paginator/Simple.hs
+++ b/src/Yesod/Paginator/Simple.hs
@@ -1,19 +1,10 @@
 module Yesod.Paginator.Simple
-    ( selectSimplePaginated
-    , simplePaginationWidget
+    ( simplePaginationWidget
     ) where
 
 import Import
 import Yesod.Paginator
 import qualified Data.Text as T
-
-selectSimplePaginated :: (PersistEntityBackend val ~ SqlBackend,
-                                PersistEntity val) =>
-                                    Int
-                                    -> [Filter val]
-                                    -> [SelectOpt val]
-                                    -> ReaderT SqlBackend Handler ([Entity val], Widget)
-selectSimplePaginated = selectPaginatedWith simplePaginationWidget
 
 simplePaginationWidget :: PageWidget App
 simplePaginationWidget page per tot = do

--- a/stack.yaml
+++ b/stack.yaml
@@ -15,6 +15,7 @@ packages:
 extra-deps:
   - typed-process-0.1.0.0
   - yesod-markdown-0.11.2
+  - yesod-paginator-0.10.1
 
 flags: {}
 

--- a/static/css/microblog.css
+++ b/static/css/microblog.css
@@ -7,6 +7,15 @@ content {
   margin-top: 24px;
 }
 
+.pagination {
+  text-align: center;
+}
+
+.pagination li {
+  margin: 10px;
+  display: inline-block;
+}
+
 .scream {
   display: block;
   border: 1px solid #ededed;

--- a/templates/home/index.hamlet
+++ b/templates/home/index.hamlet
@@ -6,3 +6,5 @@ $forall Entity sid scream <- screams
       <time datetime="#{show $ screamCreatedAt scream}">
         <a href=@{ScreamDetailR sid}>
           #{timestamp $ screamCreatedAt scream}
+
+^{pagination}


### PR DESCRIPTION
We don't want to display all 18k screams on the root once I import those
into the database. That would be horrific. Instead, we should paginate the
root so that it only shows 30 screams at a time.

This is made _dead simple_ using yesod-paginator from the imitable Pat 
Brisbin. My only issue with the lib is that it does a little _too_ much for
me. I just want to have previous and next links, I don't need the ability
to jump to an individual page.

So, to accomplish this, I'm going to wrap yesod-paginator in my own module
that exposes a simpler version of the paginator widget, only containing
links for Older and Newer screams when appropriate. _Most_ of this is taken
directly from yesod-paginator so it should be trivial to contribute back
upstream if it's wanted.