### PR TITLE
Refactor index and detail to use common markup

### DIFF
--- a/src/Handler/Home.hs
+++ b/src/Handler/Home.hs
@@ -5,6 +5,8 @@ import Helper
 import Yesod.Paginator
 import Yesod.Paginator.Simple
 
+import Handler.ScreamDetail (singleScream)
+
 getHomeR :: Handler Html
 getHomeR = do
     (screams, pagination) <- fetchScreams

--- a/src/Handler/ScreamDetail.hs
+++ b/src/Handler/ScreamDetail.hs
@@ -1,12 +1,18 @@
 module Handler.ScreamDetail
     ( getScreamDetailR
+    , singleScream
     ) where
 
 import Import
+import Helper
 
 getScreamDetailR :: ScreamId -> Handler Html
 getScreamDetailR sid = do
     scream <- runDB $ get404 sid
     defaultLayout $ do
         setTitle "Post from"
-        $(widgetFile "screams/show")
+        singleScream sid scream
+
+singleScream :: ScreamId -> Scream -> Widget
+singleScream sid scream = do
+    $(widgetFile "screams/show")

--- a/templates/home/index.hamlet
+++ b/templates/home/index.hamlet
@@ -1,10 +1,4 @@
 $forall Entity sid scream <- screams
-  <section .scream>
-    <article>
-      #{screamBody scream}
-    <div .meta>
-      <time datetime="#{show $ screamCreatedAt scream}">
-        <a href=@{ScreamDetailR sid}>
-          #{timestamp $ screamCreatedAt scream}
+  ^{singleScream sid scream}
 
 ^{pagination}

--- a/templates/screams/show.hamlet
+++ b/templates/screams/show.hamlet
@@ -1,1 +1,7 @@
-<p>#{screamBody scream}
+<section .scream>
+  <article>
+    #{screamBody scream}
+  <div .meta>
+    <time datetime="#{show $ screamCreatedAt scream}">
+      <a href=@{ScreamDetailR sid}>
+        #{timestamp $ screamCreatedAt scream}


### PR DESCRIPTION
We want our screams to be displayed consistently between the detail and
the index. To make this happen, we can export a new function from
ScreamDetail that represents a widget for a single scream. This function
can then be imported into Home, where it can be reused in the (now
greatly simplified) hamlet file. Now, any changes to the detail will be
reflected in the index and that's one less thing I need to worry about.

(lol accidentally closed this my b)