### PR TITLE
Add deployment process using docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+.dockerignore
+.env
+.git
+.sass-cache
+.stack-work
+dist/
+docker/*.plan
+docker/build/stack
+docker/build/stack-work
+docker-compose.yml
+static/tmp/
+yesod-devel/

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 dist*
 static/tmp/
 static/combined/
-config/client_session_key.aes
 *.hi
 *.o
 *.sqlite3

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 dist*
+docker/build
 static/tmp/
 static/combined/
 *.hi

--- a/bin/deploy
+++ b/bin/deploy
@@ -1,0 +1,29 @@
+#!/bin/sh
+#
+# usage: ./bin/deploy [ENV]
+#
+#   ENV defaults to staging
+#
+###
+set -e
+
+STAGING=featureless-void-staging
+PRODUCTION=featureless-void-production
+
+case "${1:-staging}" in
+  staging)
+    app="$STAGING"
+    ;;
+  production)
+    app="$PRODUCTION"
+    ./bin/promotable "$STAGING" "$PRODUCTION"
+    ;;
+  *)
+    sed '/^# \(usage:.*\)/!d; s//\1/' "$0" >&2
+    exit 64
+    ;;
+esac
+
+bin/docker-build
+docker tag featureless-void-web "registry.heroku.com/${app}/web"
+docker push "registry.heroku.com/${app}/web"

--- a/bin/docker-build
+++ b/bin/docker-build
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+set -e
+
+bin/pre-build
+
+docker build --tag featureless-void-build --file docker/Build.plan .
+
+docker run --rm \
+  --volume "$PWD/docker/build/bin:/root/.local/bin" \
+  --volume "$PWD/docker/build/stack:/root/.stack" \
+  --volume "$PWD/docker/build/stack-work:/app/.stack-work" \
+  featureless-void-build stack install --system-ghc
+
+docker build --tag featureless-void-web --file docker/Web.plan .

--- a/bin/promotable
+++ b/bin/promotable
@@ -1,0 +1,30 @@
+#!/bin/bash
+#
+# usage: promotable FROM TO
+#
+###
+
+if [ $# -lt 2 ]; then
+  sed '/^# \(usage:.*\)/!d; s//\1/' "$0" >&2
+  exit 64
+fi
+
+FROM_ENV=$1
+TO_ENV=$2
+
+set -e
+
+get_variables() {
+  cut -d: -f1 -s
+}
+
+FROM_VARS=$(heroku config --app "$FROM_ENV" | get_variables)
+TO_VARS=$(heroku config --app "$TO_ENV" | get_variables)
+
+MISSING_VARS=$(comm -23 <(echo "$FROM_VARS") <(echo "$TO_VARS"))
+
+if [[ "$MISSING_VARS" != "" ]]; then
+  echo "${TO_ENV} is missing the following keys:"
+  echo "$MISSING_VARS"
+  exit 1
+fi

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -5,11 +5,5 @@ ip-from-header: "_env:IP_FROM_HEADER:false"
 log-level:      "_env:LOG_LEVEL:info"
 s3-bucket:      "_env:S3_BUCKET:images.micro.gordonfontenot.com.dev"
 
-database:
-  user:     "_env:PGUSER:featureless_void"
-  password: "_env:PGPASS:featureless_void"
-  host:     "_env:PGHOST:localhost"
-  port:     "_env:PGPORT:5432"
-  # See config/test-settings.yml for an override during tests
-  database: "_env:PGDATABASE:featureless_void_dev"
-  poolsize: "_env:PGPOOLSIZE:10"
+database-url: "_env:DATABASE_URL:postgres://featureless_void:featureless_void@localhost:5432/featureless_void_dev"
+database-pool-size: "_env:DATABASE_POOL_SIZE:10"

--- a/docker/Build.plan
+++ b/docker/Build.plan
@@ -1,0 +1,4 @@
+FROM fpco/stack-build:lts-8.0
+
+COPY . /app
+WORKDIR /app

--- a/docker/Web.plan
+++ b/docker/Web.plan
@@ -1,0 +1,21 @@
+FROM debian:jessie
+
+ENV LANG en_US.UTF-8
+ENV PATH /app:$PATH
+
+RUN mkdir /app
+WORKDIR /app
+
+RUN apt-get update \
+  && apt-get install -y \
+    ca-certificates \
+    libgmp10 \
+    libpq5 \
+    libssl1.0.0 \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
+
+COPY docker/build/bin/* /app/
+COPY static /app/static/
+
+CMD featureless-void

--- a/featureless-void.cabal
+++ b/featureless-void.cabal
@@ -104,6 +104,7 @@ library
                  , amazonka-s3-streaming
                  , lens
                  , load-env
+                 , heroku-persistent
 
 executable         featureless-void
     if flag(library-only)

--- a/src/Foundation.hs
+++ b/src/Foundation.hs
@@ -38,9 +38,10 @@ instance Yesod App where
             Nothing -> getApprootText guessApproot app req
             Just root -> root
 
-    makeSessionBackend _ = Just <$> defaultClientSessionBackend
-        120    -- timeout in minutes
-        "config/client_session_key.aes"
+    makeSessionBackend _ =
+        Just <$> envClientSessionBackend oneWeek "SESSION_KEY"
+      where
+        oneWeek = 60 * 24 * 7
 
     yesodMiddleware = defaultYesodMiddleware . defaultCsrfMiddleware
 

--- a/src/Import/NoFoundation.hs
+++ b/src/Import/NoFoundation.hs
@@ -3,12 +3,7 @@ module Import.NoFoundation
     ( module Import
     ) where
 
-#if MIN_VERSION_classy_prelude(1,0,0)
-import ClassyPrelude.Yesod   as Import hiding (Handler)
-#else
 import ClassyPrelude.Yesod   as Import
-#endif
-
 import Model                 as Import
 import Settings              as Import
 import Settings.StaticFiles  as Import

--- a/src/Settings.hs
+++ b/src/Settings.hs
@@ -13,6 +13,7 @@ import Data.Aeson
 import Data.FileEmbed (embedFile)
 import Data.Yaml (decodeEither')
 import Database.Persist.Postgresql (PostgresConf)
+import Web.Heroku.Persist.Postgresql (fromDatabaseUrl)
 import Language.Haskell.TH.Syntax
     ( Exp
     , Name
@@ -53,7 +54,9 @@ instance FromJSON AppSettings where
                 False
 #endif
         appStaticDir              <- o .: "static-dir"
-        appDatabaseConf           <- o .: "database"
+        appDatabaseConf           <- fromDatabaseUrl
+            <$> o .: "database-pool-size"
+            <*> o .: "database-url"
         appRoot                   <- o .:? "approot"
         appHost                   <- fromString <$> o .: "host"
         appPort                   <- o .: "port"

--- a/stack.yaml
+++ b/stack.yaml
@@ -14,6 +14,8 @@ extra-deps:
   - directory-1.2.7.1
   - pandoc-types-1.16.1.1
   - texmath-0.8.6.7
+  - heroku-persistent-0.2.0
+  - heroku-0.1.2.3
 
 flags: {}
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -5,15 +5,11 @@ packages:
 
 extra-deps:
   - typed-process-0.1.0.0
-  - yesod-markdown-0.11.2
+  - yesod-markdown-0.11.3
   - yesod-paginator-0.10.1
   - amazonka-s3-streaming-0.1.0.4
   - load-env-0.1.1
-  - pandoc-1.17.2
-  - aeson-0.11.3.0
   - directory-1.2.7.1
-  - pandoc-types-1.16.1.1
-  - texmath-0.8.6.7
   - heroku-persistent-0.2.0
   - heroku-0.1.2.3
 


### PR DESCRIPTION
This adds a series of scripts and configs to let us deploy our app to 
heroku using docker. It uses the docker registry stuff that Heroku exposes
to let us push pre-built containers directly to heroku itself. It also uses
a two phase build process the reduce the container size. The first phase
builds the app itself, and so that container includes stack and ghc and all
of the other build tools needed to compile the app. The second phase
_doesn't_ need all of that crap, and so simply copies in the built app and
adds any runtime dependencies needed to run the server.

The result is an _incredibly_ fast build/deployment process (after the 
initial build) and dead-simple deployment.

Deployed app can be seen at http://featureless-void-staging.herokuapp.com/