### PR TITLE
Wrap yesod-markdown, customize markdown display

### DIFF
--- a/featureless-void.cabal
+++ b/featureless-void.cabal
@@ -24,6 +24,7 @@ library
                      Helper.Time
                      Import
                      Import.NoFoundation
+                     Markdown
                      Model
                      Query
                      Settings
@@ -107,6 +108,8 @@ library
                  , heroku-persistent
                  , uuid
                  , filepath
+                 , blaze-markup
+                 , pandoc
 
 executable         featureless-void
     if flag(library-only)

--- a/src/Handler/NewScream.hs
+++ b/src/Handler/NewScream.hs
@@ -4,7 +4,7 @@ module Handler.NewScream
     ) where
 
 import Import
-import Yesod.Markdown (Markdown, markdownField)
+import Markdown
 import qualified Helper.S3 as S3
 
 getNewScreamR :: Handler Html

--- a/src/Markdown.hs
+++ b/src/Markdown.hs
@@ -1,0 +1,37 @@
+module Markdown where
+
+import ClassyPrelude.Yesod
+import qualified Yesod.Markdown as Y
+import Database.Persist.Sql (PersistFieldSql(..))
+import Text.Blaze (ToMarkup (toMarkup))
+import Text.Pandoc
+
+newtype Markdown = Markdown Y.Markdown
+    deriving (Eq, Ord, Show, Read, PersistField, IsString, Monoid)
+
+instance PersistFieldSql Markdown where
+    sqlType _ = SqlString
+
+instance ToMarkup Markdown where
+    -- | Sanitized by default
+    toMarkup = handleError . markdownToHtml
+
+markdown :: Text -> Markdown
+markdown = Markdown . Y.Markdown
+
+unMarkdown :: Markdown -> Text
+unMarkdown (Markdown m) = Y.unMarkdown m
+
+markdownField :: Monad m => RenderMessage (HandlerSite m) FormMessage => Field m Markdown
+markdownField = Field
+    { fieldParse = parseHelper $ Right . markdown . filter (/= '\r')
+    , fieldView  = \theId name attrs val _isReq -> toWidget
+        [hamlet|$newline never
+<textarea id="#{theId}" name="#{name}" *{attrs}>#{either id unMarkdown val}
+|]
+    , fieldEnctype = UrlEncoded
+    }
+
+markdownToHtml :: Markdown -> Either PandocError Html
+markdownToHtml (Markdown m) = fmap (Y.writePandoc Y.yesodDefaultWriterOptions)
+               . Y.parseMarkdown Y.yesodDefaultReaderOptions $ m

--- a/src/Markdown.hs
+++ b/src/Markdown.hs
@@ -34,4 +34,9 @@ markdownField = Field
 
 markdownToHtml :: Markdown -> Either PandocError Html
 markdownToHtml (Markdown m) = fmap (Y.writePandoc Y.yesodDefaultWriterOptions)
-               . Y.parseMarkdown Y.yesodDefaultReaderOptions $ m
+               . Y.parseMarkdown readerOptions $ m
+
+readerOptions :: ReaderOptions
+readerOptions = Y.yesodDefaultReaderOptions
+    { readerExtensions = githubMarkdownExtensions
+    }

--- a/src/Model.hs
+++ b/src/Model.hs
@@ -4,8 +4,8 @@ module Model where
 
 import ClassyPrelude.Yesod
 import Database.Persist.Quasi
-import Yesod.Markdown
 import Yesod.Auth.HashDB (HashDBUser(..))
+import Markdown
 
 -- You can define all of your database entities in the entities file.
 -- You can find more information on persistent and how to declare entities

--- a/task/Task/TweetImport.hs
+++ b/task/Task/TweetImport.hs
@@ -4,13 +4,13 @@ module Task.TweetImport
 
 import qualified Data.ByteString.Lazy as B
 import Data.Aeson
-import Yesod.Markdown
 import System.Directory (listDirectory)
 import System.FilePath.Posix (takeFileName)
 import Network.Mime (defaultMimeLookup)
 
 import Import
 import qualified Helper.S3 as S3
+import Markdown
 
 data Tweet = Tweet
     { tweetCreatedAt :: UTCTime
@@ -65,4 +65,4 @@ mimeType :: FilePath -> Text
 mimeType = decodeUtf8 . defaultMimeLookup . pack
 
 toScream :: Tweet -> Scream
-toScream t = Scream (Markdown $ tweetBody t) (tweetCreatedAt t) (Just $ tweetId t)
+toScream t = Scream (markdown $ tweetBody t) (tweetCreatedAt t) (Just $ tweetId t)


### PR DESCRIPTION
The default markdown parser options for pandoc treat `@` symbols as an
indicator for citations. This is problematic for me, because I often use
`@` for twitter mentions, and would like to have those translated to
links at some point. More specifically, during my twitter import I'm
turning any at-mention into a link to the user's twitter profile. The
default pandoc parser breaks on these.

To solve the issue, we can create our own `Markdown` type as a `newtype`
wrapper around the `Markdown` type defined by yesod-markdown. This will
allow us to lean on that lib to do most of the heavy lifting, while
adding a thin layer (and a _little_ bit of duplication) to control the
reader/writer options ourselves.

In this case, we've switched away from the default pandoc set of
markdown extensions to the much more common (for me) GitHub extensions.