### PR TITLE
Only import the photos if the directory exists

### DIFF
--- a/task/Task/TweetImport.hs
+++ b/task/Task/TweetImport.hs
@@ -4,7 +4,7 @@ module Task.TweetImport
 
 import qualified Data.ByteString.Lazy as B
 import Data.Aeson
-import System.Directory (listDirectory)
+import System.Directory (listDirectory, doesDirectoryExist)
 import System.FilePath.Posix (takeFileName)
 import Network.Mime (defaultMimeLookup)
 
@@ -43,8 +43,12 @@ uploadImages p sid = do
 imagesFrom :: FilePath -> IO [S3.Upload]
 imagesFrom p = do
     let photosPath = p </> "photos"
-    imagePaths <- fmap (photosPath </>) <$> listDirectory photosPath
-    return $ fmap createUpload imagePaths
+    exists <- doesDirectoryExist photosPath
+    case exists of
+      True -> do
+          imagePaths <- fmap (photosPath </>) <$> listDirectory photosPath
+          return $ fmap createUpload imagePaths
+      False -> return []
 
 createUpload :: FilePath -> S3.Upload
 createUpload p = S3.Upload


### PR DESCRIPTION
We won't _always_ have a photos directory, and if we don't, listing the
contents will result in an error. To fix this we can first check to make
sure that the directory exists, and _then_ list the contents if so.

I'm like 99% sure there's an easier way to do this.