### PR TITLE
Force SSL

### DIFF
--- a/src/Foundation.hs
+++ b/src/Foundation.hs
@@ -32,18 +32,19 @@ type Form x = Html -> MForm (HandlerT App IO) (FormResult x, Widget)
 csrfTokenJs :: a -> Html
 csrfTokenJs = $(hamletFile "templates/csrf-token.hamlet")
 
+oneWeek :: Int
+oneWeek = 60 * 24 * 7
+
 instance Yesod App where
     approot = ApprootRequest $ \app req ->
         case appRoot $ appSettings app of
             Nothing -> getApprootText guessApproot app req
             Just root -> root
 
-    makeSessionBackend _ =
+    makeSessionBackend _ = sslOnlySessions $
         Just <$> envClientSessionBackend oneWeek "SESSION_KEY"
-      where
-        oneWeek = 60 * 24 * 7
 
-    yesodMiddleware = defaultYesodMiddleware . defaultCsrfMiddleware
+    yesodMiddleware = (sslOnlyMiddleware oneWeek) . defaultYesodMiddleware . defaultCsrfMiddleware
 
     defaultLayout widget = do
         mmsg <- getMessage


### PR DESCRIPTION
We don't want to let users access our site without going through SSL.
This adds the ssl session and middleware stacks into our defaults.

~~I can't tell if this actually works. Going to micro.gordonfontenot.com
doesn't force ssl for me, and I've deployed this to production. I must
be missing something.~~

This does indeed work.