### PR TITLE
Use s3's ssl urls

### DIFF
--- a/src/Helper/S3.hs
+++ b/src/Helper/S3.hs
@@ -60,9 +60,9 @@ generateURL :: Text -> Handler Text
 generateURL path = do
     bucketName <- getBucketName
     return
-        $ "http://"
+        $ "https://s3.amazonaws.com/"
         <> bucketName
-        <> ".s3.amazonaws.com/"
+        <> "/"
         <> path
 
 getBucketName :: Handler Text


### PR DESCRIPTION
We want to make sure we're using ssl across the board. This changes
the url that we generate so that it uses the ssl version instead of the
unencrypted version.