### PR TITLE
Clean up display of bare URLs

### DIFF
--- a/src/Foundation.hs
+++ b/src/Foundation.hs
@@ -54,6 +54,7 @@ instance Yesod App where
             addStylesheet $ StaticR css_screen_css
             addStylesheet $ StaticR css_microblog_css
             addScriptRemote "https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.4/jquery.js"
+            addScript     $ StaticR js_app_js
 
             $(widgetFile "default-layout")
         withUrlRenderer $(hamletFile "templates/default-layout-wrapper.hamlet")

--- a/static/css/microblog.css
+++ b/static/css/microblog.css
@@ -26,6 +26,10 @@
   padding-bottom: 15px;
 }
 
+.nowrap {
+  white-space: nowrap;
+}
+
 .scream time {
   display: inline;
 }

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -1,0 +1,17 @@
+String.prototype.truncate = function (maxLength) {
+  return this.length > maxLength
+    ? this.substring(0, maxLength) + '…'
+    : this
+};
+
+function truncateURLs() {
+  $('.scream a').each(function() {
+    displayTitle = this.innerText
+    if (displayTitle.startsWith('http')) {
+      this.innerText = displayTitle
+        .truncate(30)
+    }
+  })
+}
+
+$(document).ready(truncateURLs);

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -9,6 +9,7 @@ function truncateURLs() {
     displayTitle = this.innerText
     if (displayTitle.startsWith('http')) {
       this.innerText = displayTitle
+        .replace(/https?:\/\/(w{3}.)?/g, '')
         .truncate(30)
     }
   })

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -11,6 +11,8 @@ function truncateURLs() {
       this.innerText = displayTitle
         .replace(/https?:\/\/(w{3}.)?/g, '')
         .truncate(30)
+
+      $(this).addClass('nowrap')
     }
   })
 }


### PR DESCRIPTION
- Truncate to 30 characters
 - Remove superfluous leading characters
 - Don't add linebreaks inside a URL

See individual commits for more info.