### PR TITLE
Add strippedText helper

### DIFF
--- a/featureless-void.cabal
+++ b/featureless-void.cabal
@@ -112,6 +112,7 @@ library
                  , blaze-markup
                  , pandoc
                  , yesod-newsfeed
+                 , hxt
 
 executable         featureless-void
     if flag(library-only)

--- a/src/Markdown.hs
+++ b/src/Markdown.hs
@@ -4,7 +4,17 @@ import ClassyPrelude.Yesod
 import qualified Yesod.Markdown as Y
 import Database.Persist.Sql (PersistFieldSql(..))
 import Text.Blaze (ToMarkup (toMarkup))
+import Text.Blaze.Renderer.String (renderMarkup)
 import Text.Pandoc
+import Text.XML.HXT.Core
+    ( (//>)
+    , (>>.)
+    , (>>>)
+    , arr
+    , getText
+    , hread
+    , runLA
+    )
 
 newtype Markdown = Markdown Y.Markdown
     deriving (Eq, Ord, Show, Read, PersistField, IsString, Monoid)
@@ -15,6 +25,15 @@ instance PersistFieldSql Markdown where
 instance ToMarkup Markdown where
     -- | Sanitized by default
     toMarkup = handleError . markdownToHtml
+
+strippedText :: ToMarkup a => a -> Text
+strippedText = pack . runLA
+    (   arr toHtml
+    >>> arr renderMarkup
+    >>> hread
+    //> getText
+    >>. concat
+    )
 
 markdown :: Text -> Markdown
 markdown = Markdown . Y.Markdown


### PR DESCRIPTION
This function lets us take something that can be rendered as HTML and
render it as plain text instead. We will be using it to generate
plain-text representations of screams for things like RSS feeds and open
graph tags.