### PR TITLE
Allow SSL to be disabled via ENV

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,6 +1,7 @@
 static-dir:     "_env:STATIC_DIR:static"
 host:           "_env:HOST:*4"
 port:           "_env:PORT:3000"
+force-ssl:      "_env:FORCE_SSL:false"
 ip-from-header: "_env:IP_FROM_HEADER:false"
 log-level:      "_env:LOG_LEVEL:info"
 s3-bucket:      "_env:S3_BUCKET:images.micro.gordonfontenot.com.dev"

--- a/src/Settings.hs
+++ b/src/Settings.hs
@@ -40,6 +40,7 @@ data AppSettings = AppSettings
     , appRoot                   :: Maybe Text
     , appHost                   :: HostPreference
     , appPort                   :: Int
+    , appForceSSL               :: Bool
     , appIpFromHeader           :: Bool
     , appLogLevel               :: LogLevel
     , appMutableStatic          :: Bool
@@ -63,6 +64,7 @@ instance FromJSON AppSettings where
         appRoot                   <- o .:? "approot"
         appHost                   <- fromString <$> o .: "host"
         appPort                   <- o .: "port"
+        appForceSSL               <- o .: "force-ssl"
         appIpFromHeader           <- o .: "ip-from-header"
         appLogLevel               <- parseLogLevel <$> o .: "log-level"
         appMutableStatic          <- o .:? "mutable-static"   .!= defaultDev


### PR DESCRIPTION
We want to require SSL on production, but in dev and on staging it's
actually kind of obnoxious. Lets go ahead and keep it off, but allow it
to be enabled conditionally via ENV, which we can do on production.