### PR TITLE
Use Pandoc for generating plain text screams

### DIFF
--- a/featureless-void.cabal
+++ b/featureless-void.cabal
@@ -118,7 +118,6 @@ library
                  , blaze-markup
                  , pandoc
                  , yesod-newsfeed
-                 , hxt
                  , authenticate-oauth
                  , http-client
                  , conduit-extra

--- a/src/Handler/Feed.hs
+++ b/src/Handler/Feed.hs
@@ -10,7 +10,7 @@ import Import hiding (Feed, feedTitle, feedDescription)
 import Handler.Feed.Types
 import Query
 import Helper
-import Markdown (strippedText)
+import Markdown (plainText)
 
 getFeedRedirectR :: Handler ()
 getFeedRedirectR = redirectWith movedPermanently301 FeedR
@@ -54,7 +54,7 @@ generateFeedItem render item = do
         { feedItemId = populatedScreamId item
         , feedItemPublishedAt = rfc3339Timestamp (populatedScreamCreatedAt item)
         , feedItemUrl = render (ScreamDetailR $ populatedScreamId item)
-        , feedItemTextContent = strippedText (populatedScreamBody item)
+        , feedItemTextContent = plainText (populatedScreamBody item)
         , feedItemHtmlContent = content
         , feedItemAuthor = def
         }

--- a/src/Handler/NewScream.hs
+++ b/src/Handler/NewScream.hs
@@ -38,7 +38,7 @@ twitterCrosspostIfNecessary :: ScreamFields -> Handler (Maybe Text)
 twitterCrosspostIfNecessary fields
     | twitterCrosspostField fields = do
         images <- mapM Twitter.uploadImage $ maybeToList $ imageField fields
-        let status = strippedText . bodyField $ fields
+        let status = plainText . bodyField $ fields
         tweet <- Twitter.postTweet status images
         return $ Just $ tweetId tweet
     | otherwise = return Nothing

--- a/src/Handler/ScreamDetail.hs
+++ b/src/Handler/ScreamDetail.hs
@@ -8,7 +8,7 @@ import Text.Hamlet (hamletFile)
 import Import
 import Helper
 import Query
-import Markdown (strippedText)
+import Markdown (plainText)
 
 getScreamDetailR :: ScreamId -> Handler Html
 getScreamDetailR sid = do
@@ -19,7 +19,7 @@ getScreamDetailR sid = do
         openGraphHead (scream, images)
         singleScream (scream, images)
   where
-    screamTitle = toHtml . strippedText . screamBody . entityVal
+    screamTitle = toHtml . plainText . screamBody . entityVal
 
 singleScream :: (Entity Scream, [Entity Image]) -> Widget
 singleScream (Entity sid scream, images) = do

--- a/templates/open-graph/scream.hamlet
+++ b/templates/open-graph/scream.hamlet
@@ -1,4 +1,4 @@
-<meta property="og:title" content="#{strippedText $ screamBody scream}">
+<meta property="og:title" content="#{plainText $ screamBody scream}">
 <meta property="og:description" content="Gordon Fontenot's microblog">
 <meta property="og:type" content="article">
 <meta property="og:url" content="@{ScreamDetailR sid}">


### PR DESCRIPTION
Previously, we were using hxt for generating the plain text versions of
our screams. This meant going from Markdown (Text) to Pandoc to Html to
Text. On top of being fairly inefficient, it also meant that during the
round trip we lost any newline characters that we had added to the text.

To simplify (and improve) things, we can instead use Pandoc directly to
print to plain text. This is possible out of the box by using
`writePlain` and a very simple set of writer options. However, this does
have one unexpected side effect of not stripping inline styles (even
though the docs say that it does). This means that `_Hello_ __world__`
would render as `_Hello_ WORLD`. I'd rather it just strip these out
entirely, so I'm adding a simple filter into the mix that strips these
elements from the document before writing.

I'm also taking the opportunity to rename this to `plainText` which I
like a bit more.