### PR TITLE
Remove yesod-markdown dependency

### DIFF
--- a/featureless-void.cabal
+++ b/featureless-void.cabal
@@ -103,7 +103,6 @@ library
                  , time
                  , case-insensitive
                  , wai
-                 , yesod-markdown
                  , yesod-auth-hashdb
                  , pwstore-fast
                  , yesod-paginator
@@ -121,6 +120,7 @@ library
                  , authenticate-oauth
                  , http-client
                  , conduit-extra
+                 , xss-sanitize
 
 executable         featureless-void
     if flag(library-only)
@@ -151,7 +151,6 @@ executable         task
                      , optparse-applicative
                      , text
                      , yesod-core
-                     , yesod-markdown
 
     ghc-options:       -Wall -threaded -rtsopts -with-rtsopts=-N -O2
 

--- a/src/Markdown.hs
+++ b/src/Markdown.hs
@@ -1,12 +1,29 @@
-module Markdown where
+module Markdown
+    ( Markdown(..)
+    , markdownField
+    , plainText
+    ) where
 
 import ClassyPrelude.Yesod
-import qualified Yesod.Markdown as Y
 import Database.Persist.Sql (PersistFieldSql(..))
 import Text.Blaze (ToMarkup (toMarkup))
+import Text.HTML.SanitizeXSS (sanitizeBalance)
 import Text.Pandoc
+    ( Pandoc(..)
+    , PandocError(..)
+    , ReaderOptions(..)
+    , WriterOptions(..)
+    , WrapOption(..)
+    , Inline(..)
+    , readMarkdown
+    , writeHtmlString
+    , writePlain
+    , githubMarkdownExtensions
+    , plainExtensions
+    , topDown
+    )
 
-newtype Markdown = Markdown Y.Markdown
+newtype Markdown = Markdown { unMarkdown :: Text }
     deriving (Eq, Ord, Show, Read, PersistField, IsString, Monoid)
 
 instance PersistFieldSql Markdown where
@@ -14,13 +31,11 @@ instance PersistFieldSql Markdown where
 
 instance ToMarkup Markdown where
     -- | Sanitized by default
-    toMarkup = handleError . markdownToHtml
-
-toPandoc :: Markdown -> Pandoc
-toPandoc m = either mempty id $ parse m
-  where
-    parse :: Markdown -> Either PandocError Pandoc
-    parse = readMarkdown readerOptions . unpack . unMarkdown
+    toMarkup = preEscapedToMarkup
+               . sanitizeBalance
+               . pack
+               . writeHtmlString htmlWriterOptions
+               . toPandoc
 
 plainText :: Markdown -> Text
 plainText = pack
@@ -28,21 +43,9 @@ plainText = pack
             . topDown removeInlineStyles
             . toPandoc
 
-removeInlineStyles :: [Inline] -> [Inline]
-removeInlineStyles ((Emph lst) : xs) = removeInlineStyles $ lst ++ xs
-removeInlineStyles ((Strong lst) : xs) = removeInlineStyles $ lst ++ xs
-removeInlineStyles (x : xs) = x : removeInlineStyles xs
-removeInlineStyles [] = []
-
-markdown :: Text -> Markdown
-markdown = Markdown . Y.Markdown
-
-unMarkdown :: Markdown -> Text
-unMarkdown (Markdown m) = Y.unMarkdown m
-
 markdownField :: Monad m => RenderMessage (HandlerSite m) FormMessage => Field m Markdown
 markdownField = Field
-    { fieldParse = parseHelper $ Right . markdown . filter (/= '\r')
+    { fieldParse = parseHelper $ Right . Markdown . filter (/= '\r')
     , fieldView  = \theId name attrs val _isReq -> toWidget
         [hamlet|$newline never
 <textarea id="#{theId}" name="#{name}" *{attrs}>#{either id unMarkdown val}
@@ -50,16 +53,33 @@ markdownField = Field
     , fieldEnctype = UrlEncoded
     }
 
-markdownToHtml :: Markdown -> Either PandocError Html
-markdownToHtml (Markdown m) = fmap (Y.writePandoc Y.yesodDefaultWriterOptions)
-               . Y.parseMarkdown readerOptions $ m
+removeInlineStyles :: [Inline] -> [Inline]
+removeInlineStyles ((Emph lst) : xs) = removeInlineStyles $ lst ++ xs
+removeInlineStyles ((Strong lst) : xs) = removeInlineStyles $ lst ++ xs
+removeInlineStyles (x : xs) = x : removeInlineStyles xs
+removeInlineStyles [] = []
+
+toPandoc :: Markdown -> Pandoc
+toPandoc m = either mempty id $ parse m
+  where
+    parse :: Markdown -> Either PandocError Pandoc
+    parse = readMarkdown readerOptions . unpack . unMarkdown
 
 plainWriterOptions :: WriterOptions
 plainWriterOptions = def
     { writerExtensions = plainExtensions
     }
 
+htmlWriterOptions :: WriterOptions
+htmlWriterOptions =  def
+    { writerHtml5     = True
+    , writerWrapText  = WrapNone
+    , writerHighlight = True
+    }
+
 readerOptions :: ReaderOptions
-readerOptions = Y.yesodDefaultReaderOptions
+readerOptions = def
     { readerExtensions = githubMarkdownExtensions
+    , readerSmart = True
+    , readerParseRaw = True
     }

--- a/task/Task/TweetImport.hs
+++ b/task/Task/TweetImport.hs
@@ -69,4 +69,4 @@ mimeType :: FilePath -> Text
 mimeType = decodeUtf8 . defaultMimeLookup . pack
 
 toScream :: Tweet -> Scream
-toScream t = Scream (markdown $ tweetBody t) (tweetCreatedAt t) (Just $ tweetId t)
+toScream t = Scream (Markdown $ tweetBody t) (tweetCreatedAt t) (Just $ tweetId t)


### PR DESCRIPTION
We were already duplicating a good chunk of the yesod-markdown lib
because we wanted to customize our reading options. As it turns out,
with a bit more code we can remove the dependency on the lib entirely,
which will have the added benefit of removing a bit more implicit
behavior, and expose our preferences directly.

While we're in here, I'm going to go ahead and reorganize things and
explicitly declare our imports/exports. This will make refactoring
easier in the future.