### PR TITLE
Don't escape encoded markup

### DIFF
--- a/templates/feed/xml/items.hamlet
+++ b/templates/feed/xml/items.hamlet
@@ -1,7 +1,7 @@
 $forall item <- feedItems feed
   <item>
     <description><![CDATA[#{feedItemTextContent item}]]>
-    <content:encoded><![CDATA[#{feedItemHtmlContent item}]]>
+    <content:encoded><![CDATA[#{preEscapedToMarkup $ feedItemHtmlContent item}]]>
     <pubDate>#{feedItemPublishedAt item}
     <guid isPermaLink="false">#{feedItemUrl item}
     <link>#{feedItemUrl item}


### PR DESCRIPTION
Yesod defaults to escaping markup when using interpolation in Hamlet. This is
a good default, but we've actually already converted our html content to
rendered html, so escaping it here is counter productive.

To solve this, we can convert from `Text` to `Html` explicitly ourselves by
specifying that the content is already pre-escaped.

This will fix the html rendering in our RSS feeds.